### PR TITLE
Update ReadMe, help with dsk, tap images and explain CLOAD issue

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -9,23 +9,25 @@ Oric-1 and Oric Atmos re-implementation on a modern FPGA.
 
 ### Background:
 
-There is one version made and ported by [Gehstock](https://github.com/Gehstock/Mist_FPGA/tree/master/Computer_MiST/OricInFPGA_MiST) at github , but it's far to be functional like an Oric. Gehstock's version for MiST board was realeased as a proof of concept with only 32KB RAM (no oric existed with that memory, only **16K** ,**48K** and **64K**)(64KB is real RAM) so there were errors managing **HIRES** mode) and no way to load audio tapes and lots of graphics errors on screen.
+There is one version made and ported by [Gehstock](https://github.com/Gehstock/Mist_FPGA/tree/master/Computer_MiST/OricInFPGA_MiST) at GitHub, but it's far from a functional Oric.
+Gehstock's version for MiST board was realeased as a proof of concept with only 32KB RAM (no Oric existed with that memory, only **16K** ,**48K** and **64K**)(64KB is real RAM) so there were errors managing **HIRES** mode) and no way to load audio tapes and lots of graphics errors on screen.
 
 ### What can you expect from Oric 48K in MiST and SiDi FPGA ?
 
-This project began in november 2019 with the aim to preserve the Oric's computer family into fpga.
+This project began in november 2019 with the aim to preserve the Oric's computer family into FPGA.
 
 Actually Oric 1, Oric Atmos and Microdisc are fully functional.
+
 * **ULA HCS10017**.
 * **VIA 6522**.
 * **CPU 6502**.
 * Full 64KB of **RAM**.
 * Keyboard managed by GI-8912.
 * Sound (**AY-3-8910**).
-* switchable **ROM** (between 1.1a ATMOS version and 1.0 ORIC 1 version).
+* Switchable **ROM** (between 1.1a ATMOS version and 1.0 ORIC 1 version).
 * Tape loading working (via audio cable on the RX pin).
 * Oric Microdisc implementation vía **CUMULUS**
-* Disc Read / Write operations fully supported with EDSK (The same as amstrad cpc) format.
+* Disc Read / Write operations fully supported with EDSK (The same as Amstrad CPC) format.
 * Disc Sedoric/OricDOS Operating System Loading fully working
 
 ### TODO
@@ -35,7 +37,9 @@ Actually Oric 1, Oric Atmos and Microdisc are fully functional.
 
 ### KNOWN BUGS
 
-   * None at the moment..., but if You find one, let Us know, please.
+* Issues loading files on multipart dsks; i.e. programs using CLOAD to load in other data from the dsk.
+
+..if you find others, let us know, please.
 
 ### HOW TO USE AN ORIC 1 & ATMOS WITH MiST, MiSTica and SiDi FPGA boards.
 
@@ -48,10 +52,10 @@ Actually Oric 1, Oric Atmos and Microdisc are fully functional.
    * F11 - Reset. Use F11 to reboot once a DSK is selected at OSD
    * F12 - OSD Main Menu.
 
-   ![shortcuts](img/shorcuts.jpg?raw=true "Keyboard shortcuts")   
+   ![shortcuts](img/shorcuts.jpg?raw=true "Keyboard shortcuts")
 
    * Activate FDC controller at OSD MENU
-   * Select an Image from /ORIC directory, exit OSD and press F11. System will boot inmeddiately
+   * Select an Image from games/Oric directory, exit OSD and press F11. System will boot inmeddiately
 
 
 
@@ -69,18 +73,36 @@ Actually Oric 1, Oric Atmos and Microdisc are fully functional.
 
 * Kudos to: Sorgelig, Gehstock, DesUBIKado, RetroWiki and friends.
 
-## About disk images.
+## About disk images
 
-  Despite of the .dsk extension, Disk images are the defacto standard **edsk** for disk preservation (also known as "AMSTRAD CPC EXTENDED FORMAT"). To convert images
-  from the oric "dsk" to the needed "dsk" you need the [HxCFloppyEmulator software] (https://hxc2001.com/download/floppy_drive_emulator/HxCFloppyEmulator_soft.zip).
+  Despite the .dsk extension, Disk images must use the defacto standard **edsk** for disk preservation (also known as "AMSTRAD CPC EXTENDED FORMAT"). To convert images
+  from the Oric "dsk" to the needed "edsk" you need the [HxCFloppyEmulator](https://hxc2001.com/download/floppy_drive_emulator/HxCFloppyEmulator_soft.zip) tool
+  (source code [here](https://sourceforge.net/projects/hxcfloppyemu/)).
 
-  Load the disk oric disk and export it as **CPC DSK file** the resulting image should load flawlessly on the Oric.
-  This images are also compatible with fastfloppy firmware on gothek, cuamana reborn, etc working with real orics.
+  Load the Oric disk and export it as **CPC DSK file** The resulting image should load flawlessly on the Oric. Always use a `.dsk` extension for your output file
+  These images are also compatible with fastfloppy firmware on gothek, cuamana reborn, etc. working with real Orics.
+
+## About tape images
+
+  Loading from a `tap` file is **NOT** currently supported in this core. But you can convert `.tap` files to `dsk` with the [OricDSK Disc Manager Tool](https://github.com/teiram/oric-dsk-manager).
+  Then convert the resulting "dsk" to the supported "edsk" (CPC format) with [HxCFloppyEmulator](https://hxc2001.com/download/floppy_drive_emulator/HxCFloppyEmulator_soft.zip) as explained above.
+
+  Tape to dsk conversion is also possible with [tap2dsk](https://sourceforge.net/projects/euphorictools/files/disk%20image%20tools/Sedoric%20tool/) from
+  the [Euphoric Tools](https://sourceforge.net/projects/euphorictools/) pack.
+
+  This core does support real-world (physical) Tape loading (via audio cable on the RX pin).
+
+## Troubleshooting disks
+
+  * If dsk is bootable, simply select the image, exit the MiSTer OSD, then press F11.
+  * If dsk is NOT bootable, after inserting, try `DIR` to list contents then `!NAME_OF_FILE_TO_RUN` to load and run.
+  * If you see errors like `Insert System Disk` try loading the SEDORIC first, exiting to the BASIC prompt, insert your dsk and use `DIR`, `!NAME_OF_FILE_TO_RUN`.
+
+  *NOTE*: There are known loading issues with multipart dsks; e.g. programs that use CLOAD to load in additional data from the dsk.
 
 ## Joystick
 
- almost all the Oric games dont have joystick support, but you can "map" the
-most used keys to a joystick adding thist to your **mist.ini** file.
+Almost all the Oric games don't have joystick support, but you can "map" the most used keys to a joystick adding by this to your **mist.ini** file.
 
 	[oric]
 	joy_key_map=1,4f     ; cursor right
@@ -89,11 +111,11 @@ most used keys to a joystick adding thist to your **mist.ini** file.
 	joy_key_map=8,52     ; cursor up
 	joy_key_map=10,2c    ; button A as SPACE
 	joy_key_map=40,28    ; button SEL as ENTER
-	joy_key_map=80,44    ; button STA as F11 
+	joy_key_map=80,44    ; button STA as F11
 
 ## Software redistribution.
 
- In the dsk directory, you will find some disk images in the proper format. 
+ In the dsk directory, you will find some disk images in the proper format.
 
 * **SEDORIC 4.0** operating System disk image redistributed with permission from Symoon.
 * **Blake's 7** game, redistributed with permission of chema enguita you can download manual and additional info from [Defence force](http://www.defence-force.org/index.php?page=games&game=blakes7)

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -37,7 +37,7 @@ Actually Oric 1, Oric Atmos and Microdisc are fully functional.
 
 ### KNOWN BUGS
 
-* Issues loading files on multipart dsks; i.e. programs using CLOAD to load in other data from the dsk.
+* Issue [loading files on multipart dsks](https://github.com/MiSTer-devel/Oric_MiSTer/issues/4); i.e. programs using CLOAD to load in other data from the dsk.
 
 ..if you find others, let us know, please.
 
@@ -98,7 +98,7 @@ Actually Oric 1, Oric Atmos and Microdisc are fully functional.
   * If dsk is NOT bootable, after inserting, try `DIR` to list contents then `!NAME_OF_FILE_TO_RUN` to load and run.
   * If you see errors like `Insert System Disk` try loading the SEDORIC first, exiting to the BASIC prompt, insert your dsk and use `DIR`, `!NAME_OF_FILE_TO_RUN`.
 
-  *NOTE*: There are known loading issues with multipart dsks; e.g. programs that use CLOAD to load in additional data from the dsk.
+  *NOTE*: There are known [loading issues](https://github.com/MiSTer-devel/Oric_MiSTer/issues/4) with multipart dsks; e.g. programs that use CLOAD to load in additional data from the dsk.
 
 ## Software redistribution.
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -100,19 +100,6 @@ Actually Oric 1, Oric Atmos and Microdisc are fully functional.
 
   *NOTE*: There are known loading issues with multipart dsks; e.g. programs that use CLOAD to load in additional data from the dsk.
 
-## Joystick
-
-Almost all the Oric games don't have joystick support, but you can "map" the most used keys to a joystick adding by this to your **mist.ini** file.
-
-	[oric]
-	joy_key_map=1,4f     ; cursor right
-	joy_key_map=2,50     ; cursor left
-	joy_key_map=4,51     ; cursor down
-	joy_key_map=8,52     ; cursor up
-	joy_key_map=10,2c    ; button A as SPACE
-	joy_key_map=40,28    ; button SEL as ENTER
-	joy_key_map=80,44    ; button STA as F11
-
 ## Software redistribution.
 
  In the dsk directory, you will find some disk images in the proper format.


### PR DESCRIPTION
Hi there!

First up thanks for your awesome work on this core! It's another step in me re-living my childhood computer life!

I've spent some time with the Oric core over the weekend, and was trying to figure out how to run the very first video game I ever played ([Invaders from PSS](https://www.oric.org/software/invaders_pss_-1126.html) on the Oric Atmos, tap file is [here](https://cdn.oric.org//games/software//i/invaders/invpss.tap)).  

I dug around the web searching for how I could convert the Oric tap format to dsk, then to edsk.  I finally had some luck with this [dsk file](https://we.tl/t-Gn5CNAlBHt). **But** it tries to load other files from the disk when running the main program listing (using the CLOAD command) this fails/hangs without any error, meaning I can't play this game ☹️ 

I spoke with [Jose Enguita](https://sourceforge.net/u/jmenguita/) about this (who I believed helped debug this core a little). He mentioned that:

> ...getting a tape program to work from a disk is not something easy. With multipart games it won't work properly. Also there seems to be a bug in the disk emulation and my Blake's 7 game gets stuck around the beginning of Episode 2.

So this PR includes updates to the README for the following:

* Added section about tap images (i.e. not supported, but explains how to convert to dsk, edsk)
* Provided some more guidance on using dsk images, including how to load non-bootable dsks 
* Some typos fixed, title-cased Oric everywhere etc.
* Removed 🕹 Joystick section as advised by @sorgelig 
* Mentioned issue with multipart files and CLOAD