### PR TITLE
Adding support for joysticks

### DIFF
--- a/Oric.sv
+++ b/Oric.sv
@@ -231,6 +231,8 @@ localparam CONF_STR = {
 	"P1O[51:50],Tape Audio,Mute,Low,High;",
 	"P1O[52],Tape Input,File,ADC;",
 	"P1-;",
+	"P1O[55:54],Joystick Adapter,None,PASE,IJK;",
+	"P1-;",
 	"P1O[122:121],Aspect ratio,Original,Full Screen,[ARC1],[ARC2];",
 	"P1O[12:10],Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%;",
 	"P1O[16:15],Scale,Normal,V-Integer,Narrower HV-Integer,Wider HV-Integer;",
@@ -240,6 +242,7 @@ localparam CONF_STR = {
 	"h1O[4:3],ROM,Oric Atmos,Oric 1,Loadable Bios;",
 	
 	"-;",
+	"J,Fire;",
 	"R0,Reset & Apply;",
 	"V,v",`BUILD_DATE
 };
@@ -247,6 +250,8 @@ localparam CONF_STR = {
 wire [1:0] tapeVolume  = status[51:50];
 wire       tapeUseADC = status[52];
 wire       tapeRewind = status[53];
+wire [1:0] joystick_adapter = status[55:54];
+
 ///////////////////////////////////////////////////
 
 wire locked;
@@ -287,7 +292,8 @@ end
 
 wire  [10:0] ps2_key;
 
-wire  [15:0] joy;
+wire  [15:0] joystick_0;
+wire  [15:0] joystick_1;
 wire   [1:0] buttons;
 wire         forced_scandoubler;
 wire [127:0] status;
@@ -325,7 +331,8 @@ hps_io #(.CONF_STR(CONF_STR), .VDNUM(4)) hps_io
 
 	.ps2_key(ps2_key),
 
-	.joystick_0(joy),
+	.joystick_0(joystick_0),
+	.joystick_1(joystick_1),
 	.buttons(buttons),
 	.forced_scandoubler(forced_scandoubler),
 	.status(status),
@@ -448,8 +455,9 @@ oricatmos oricatmos
 	.ram_q            (ram_q),
 	.ram_oe           (),
 	.ram_we           (ram_we),
-	.joystick_0       (0),
-	.joystick_1       (0),
+	.joystick_adapter (joystick_adapter),
+	.joystick_0       (joystick_0),
+	.joystick_1       (joystick_1),
 	.fd_led           (led_disk),
 	.fdd_ready        (fdd_ready),
 	.fdd_busy         (fdd_busy),

--- a/files.qip
+++ b/files.qip
@@ -5,6 +5,7 @@ set_global_assignment -name VERILOG_FILE rtl/cassette.v
 set_global_assignment -name VERILOG_FILE rtl/cas_sig_gen.v
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/wd1793.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/keyboard.sv 
+set_global_assignment -name SYSTEMVERILOG_FILE rtl/joystick.sv 
 set_global_assignment -name VHDL_FILE rtl/microdisc.vhd
 set_global_assignment -name VHDL_FILE rtl/rom/MICRODIS.vhd
 set_global_assignment -name VHDL_FILE rtl/rom/BASIC10.vhd

--- a/rtl/joystick.sv
+++ b/rtl/joystick.sv
@@ -1,0 +1,66 @@
+// Vincent Bénony 2023
+
+module joystick
+(
+	input			   clk_sys,
+	input  [7:0]   joystick_0,
+	input  [7:0]	joystick_1,
+	input	 [1:0]	adapter,
+	input          via_strobe,
+	input  [7:0]   via_pa_in,
+
+	output [7:0]	joy_mask,
+	output [7:0]	joy_value
+);
+
+reg [7:0] mask;
+reg [7:0] value;
+
+always @(posedge clk_sys) begin
+
+	mask[7:0]  = 8'b00000000;
+	value[7:0] = 8'b00000000;
+	
+	case (adapter)
+		// PASE
+		1:
+			if (via_pa_in[7] == 1) begin	         // Joystick 0 selected
+				mask[0] = joystick_0[1];            // Left
+				mask[1] = joystick_0[0];            // Right
+				mask[3] = joystick_0[2];            // Down
+				mask[4] = joystick_0[3];            // Up
+				mask[5] = joystick_0[4];            // Fire
+			end else if (via_pa_in[6] == 1) begin	// Joystick 1 selected
+				mask[0] = joystick_1[1];            // Left
+				mask[1] = joystick_1[0];            // Right
+				mask[3] = joystick_1[2];            // Down
+				mask[4] = joystick_1[3];            // Up
+				mask[5] = joystick_1[4];            // Fire
+			end
+
+		// IJK
+		2:
+			if (via_strobe == 0) begin	// Respond only when the printer stobe is active (low)
+				joy_mask[5] = 1'b1;     // Signal that the IJK interface is present
+				
+				if (via_pa_in[6] == 1) begin				// Joystick 0 selected
+					mask[0] = joystick_0[0];            // Right
+					mask[1] = joystick_0[1];            // Left
+					mask[2] = joystick_0[4];            // Fire
+					mask[3] = joystick_0[2];            // Down
+					mask[4] = joystick_0[3];            // Up
+				end else if (via_pa_in[7] == 1) begin	// Joystick 1 selected
+					mask[0] = joystick_1[0];            // Right
+					mask[1] = joystick_1[1];            // Left
+					mask[2] = joystick_1[4];            // Fire
+					mask[3] = joystick_1[2];            // Down
+					mask[4] = joystick_1[3];            // Up
+				end
+			end
+	endcase
+	
+	joy_mask[7:0]  <= mask[7:0];
+	joy_value[7:0] <= value[7:0];
+end
+
+endmodule

--- a/rtl/keyboard.sv
+++ b/rtl/keyboard.sv
@@ -1,5 +1,5 @@
 // Dave Wood 2019
-
+// Updated by Vincent Bénony in 2023
 
 module keyboard
 (
@@ -9,13 +9,12 @@ module keyboard
 	input          key_extended, // extended code
 	input          key_strobe,   // strobe
 	input  [7:0]   key_code,     // key scan code
-	input  [2:0]	col,
-	input	 [7:0]	row,
-	output [7:0]	ROWbit,
-	output			swrst,
-	output         swnmi
+	input  [2:0]	col,         // column index used by the mutiplexer
+	input [7:0] row_mask,        // row mask as prepared by the PSG
+	output reg kbd_int,
+	output reg swrst,
+	output reg swnmi
 );
-
 
 reg sw0 = 1'b0;
 reg sw1 = 1'b0;
@@ -77,22 +76,10 @@ reg swsq = 1'b0; 	// '
 reg swsc = 1'b0;		// ;
 reg swesc = 1'b0;	// escape
 reg swctl = 1'b0;	// left ctrl
-
-
-//reg swrst = 0;
-reg swf1 = 1'b0;
-reg swf2 = 1'b0;
-reg swf3 = 1'b0;
-reg swf4 = 1'b0;
-reg swf5 = 1'b0;
-reg swf6 = 1'b0;
-
-
 	
 always @(posedge clk_sys) begin
-	
 	if(key_strobe) begin
-		casex(key_code)
+		case(key_code)
 			'h045: sw0      			<= key_pressed; // 0
 			'h016: sw1       			<= key_pressed; // 1
 			'h01e: sw2   				<= key_pressed; // 2
@@ -130,10 +117,10 @@ always @(posedge clk_sys) begin
 			'h035: swy					<= key_pressed; // y
 			'h01a: swz					<= key_pressed; // z
 	
-			'hX75: swU           	<= key_pressed; // up
-			'hX72: swD		        	<= key_pressed; // down
-			'hx6b: swL					<= key_pressed; // left
-			'hx74: swR					<= key_pressed; // right
+			'h075: swU           	<= key_pressed; // up
+			'h072: swD		        	<= key_pressed; // down
+			'h06b: swL					<= key_pressed; // left
+			'h074: swR					<= key_pressed; // right
 			'h059: swrs					<= key_pressed; // right shift
 			'h012: swls					<= key_pressed; // left shift
 			'h029: swsp					<= key_pressed; // space
@@ -143,8 +130,8 @@ always @(posedge clk_sys) begin
 			'h04a: swfs					<= key_pressed; // forward slash
 			'h055: sweq					<= key_pressed; // equals
 			'h011: swfcn				<= key_pressed; // ALT
-			'hx66: swdel				<= key_pressed; // delete
-			'hx71: swdel				<= key_pressed; // delete
+			'h066: swdel				<= key_pressed; // delete
+			'h071: swdel				<= key_pressed; // delete
 			'h05b: swrsb				<= key_pressed; // right sq bracket
 			'h054: swlsb				<= key_pressed; // left sq bracket
 			'h05d: swbs					<= key_pressed; // back slash h05d
@@ -154,98 +141,85 @@ always @(posedge clk_sys) begin
 			'h076: swesc				<= key_pressed; // escape
 			'h014: swctl				<= key_pressed; // left control
 			'h078: swrst            <= key_pressed; // F11 reset 
-			'h009: swnmi      		<= key_pressed; // F10 break
-			'h005: swf1	      		<= key_pressed; // f1
-			'h006: swf2	      		<= key_pressed; // f2
-			'h004: swf3	      		<= key_pressed; // f3
-			'h00c: swf4	      		<= key_pressed; // f4
-			'h003: swf5	      		<= key_pressed; // f5
-			'h00b: swf6	      		<= key_pressed; // f6
-			
+			'h009: swnmi      		<= key_pressed; // F10 break		
 		endcase
 	end
 end
 					
 always @(posedge clk_sys) begin
-		if (col == 3'b111) begin
-			ROWbit[7] <= sweq;
-			ROWbit[6] <= swf1;
-			ROWbit[5] <= swret;
-			ROWbit[4] <= swrs;
-			ROWbit[3] <= swfs;
-			ROWbit[2] <= sw0;
-			ROWbit[1] <= swl;
-			ROWbit[0] <= sw8;
+		if (col == 7) begin
+			kbd_int <= (sweq  & ~row_mask[7])
+			         | (swret & ~row_mask[5])
+			         | (swrs  & ~row_mask[4])
+			         | (swfs  & ~row_mask[3])
+			         | (sw0   & ~row_mask[2])
+			         | (swl   & ~row_mask[1])
+			         | (sw8   & ~row_mask[0]);
 		end
-		else if (col == 3'b110) begin
-			ROWbit[7] <= sww;
-			ROWbit[6] <= sws;
-			ROWbit[5] <= swa;
-			ROWbit[4] <= swf2;
-			ROWbit[3] <= swe;
-			ROWbit[2] <= swg;
-			ROWbit[1] <= swh;
-			ROWbit[0] <= swy;
+		else if (col == 6) begin
+			kbd_int <= (sww & ~row_mask[7])
+			         | (sws & ~row_mask[6])
+			         | (swa & ~row_mask[5])
+			         | (swe & ~row_mask[3])
+			         | (swg & ~row_mask[2])
+			         | (swh & ~row_mask[1])
+			         | (swy & ~row_mask[0]);
 		end
-		else if (col == 3'b101) begin
-			ROWbit[7] <= swlsb;
-			ROWbit[6] <= swrsb;
-			ROWbit[5] <= swdel;
-			ROWbit[4] <= swfcn;
-			ROWbit[3] <= swp;
-			ROWbit[2] <= swo;
-			ROWbit[1] <= swi;
-			ROWbit[0] <= swu;
+		else if (col == 5) begin
+			kbd_int <= (swlsb & ~row_mask[7])
+			         | (swrsb & ~row_mask[6])
+			         | (swdel & ~row_mask[5])
+			         | (swfcn & ~row_mask[4])
+			         | (swp   & ~row_mask[3])
+			         | (swo   & ~row_mask[2])
+			         | (swi   & ~row_mask[1])
+			         | (swu   & ~row_mask[0]);
 		end
-		else if (col == 3'b100) begin
-			ROWbit[7] <= swR;
-			ROWbit[6] <= swD;
-			ROWbit[5] <= swL;
-			ROWbit[4] <= swls;
-			ROWbit[3] <= swU;
-			ROWbit[2] <= swdot;
-			ROWbit[1] <= swcom;
-			ROWbit[0] <= swsp;
+		else if (col == 4) begin
+			kbd_int <= (swR   & ~row_mask[7])
+			         | (swD   & ~row_mask[6])
+			         | (swL   & ~row_mask[5])
+			         | (swls  & ~row_mask[4])
+			         | (swU   & ~row_mask[3])
+			         | (swdot & ~row_mask[2])
+			         | (swcom & ~row_mask[1])
+			         | (swsp  & ~row_mask[0]);
 		end
-		else if (col == 3'b011) begin
-			ROWbit[7] <= swsq;
-			ROWbit[6] <= swbs;
-			ROWbit[5] <= swf3;
-			ROWbit[4] <= swf4;
-			ROWbit[3] <= swdsh;
-			ROWbit[2] <= swsc;
-			ROWbit[1] <= sw9;
-			ROWbit[0] <= swk;
+		else if (col == 3) begin
+			kbd_int <= (swsq  & ~row_mask[7])
+			         | (swbs  & ~row_mask[6])
+			         | (swdsh & ~row_mask[3])
+			         | (swsc  & ~row_mask[2])
+			         | (sw9   & ~row_mask[1])
+			         | (swk   & ~row_mask[0]);
 		end
-		else if (col == 3'b010) begin
-			ROWbit[7] <= swc;
-			ROWbit[6] <= sw2;
-			ROWbit[5] <= swz;
-			ROWbit[4] <= swctl;
-			ROWbit[3] <= sw4;
-			ROWbit[2] <= swb;
-			ROWbit[1] <= sw6;
-			ROWbit[0] <= swm;
+		else if (col == 2) begin
+			kbd_int <= (swc   & ~row_mask[7])
+			         | (sw2   & ~row_mask[6])
+			         | (swz   & ~row_mask[5])
+			         | (swctl & ~row_mask[4])
+			         | (sw4   & ~row_mask[3])
+			         | (swb   & ~row_mask[2])
+			         | (sw6   & ~row_mask[1])
+			         | (swm   & ~row_mask[0]);
 		end
-		else if (col == 3'b001) begin
-			ROWbit[7] <= swd;
-			ROWbit[6] <= swq;
-			ROWbit[5] <= swesc;
-			ROWbit[4] <= swf5;
-			ROWbit[3] <= swf;
-			ROWbit[2] <= swr;
-			ROWbit[1] <= swt;
-			ROWbit[0] <= swj;
+		else if (col == 1) begin
+			kbd_int <= (swd   & ~row_mask[7])
+			         | (swq   & ~row_mask[6])
+			         | (swesc & ~row_mask[5])
+			         | (swf   & ~row_mask[3])
+			         | (swr   & ~row_mask[2])
+			         | (swt   & ~row_mask[1])
+			         | (swj   & ~row_mask[0]);
 		end
-		else if (col == 3'b000) begin
-			ROWbit[7] <= sw3;
-			ROWbit[6] <= swx;
-			ROWbit[5] <= sw1;
-			ROWbit[4] <= swf6;
-			ROWbit[3] <= swv;
-			ROWbit[2] <= sw5;
-			ROWbit[1] <= swn;
-			ROWbit[0] <= sw7;
+		else if (col == 0) begin
+			kbd_int <= (sw3 & ~row_mask[7])
+			         | (swx & ~row_mask[6])
+			         | (sw1 & ~row_mask[5])
+			         | (swv & ~row_mask[3])
+			         | (sw5 & ~row_mask[2])
+			         | (swn & ~row_mask[1])
+			         | (sw7 & ~row_mask[0]);
 		end
 end
 endmodule

--- a/rtl/oricatmos.vhd
+++ b/rtl/oricatmos.vhd
@@ -138,13 +138,15 @@ ARCHITECTURE RTL OF oricatmos IS
 	SIGNAL VIA_DO : STD_LOGIC_VECTOR(7 DOWNTO 0);
 	-- Clavier : émulation par port PS2
 	SIGNAL KEY_ROW : STD_LOGIC_VECTOR(7 DOWNTO 0);
+	SIGNAL kbd_int : STD_LOGIC;
 	SIGNAL KEYB_RESETn : STD_LOGIC;
 	SIGNAL KEYB_NMIn : STD_LOGIC;
 
 	-- PSG
 	SIGNAL psg_bdir : STD_LOGIC;
 	SIGNAL psg_bc1 : STD_LOGIC;
-	SIGNAL ym_o_ioa : STD_LOGIC_VECTOR (7 DOWNTO 0);
+	SIGNAL psg_ioa_out : STD_LOGIC_VECTOR (7 DOWNTO 0);
+	SIGNAL psg_iob_out : STD_LOGIC_VECTOR (7 DOWNTO 0);
 	SIGNAL psg_sample_ok : STD_LOGIC;
 	-- ULA    
 	SIGNAL ula_phi2 : STD_LOGIC;
@@ -202,8 +204,8 @@ ARCHITECTURE RTL OF oricatmos IS
 			key_strobe : IN STD_LOGIC;
 			key_code : IN STD_LOGIC_VECTOR(7 DOWNTO 0);
 			col : IN STD_LOGIC_VECTOR(2 DOWNTO 0);
-			row : IN STD_LOGIC_VECTOR(7 DOWNTO 0);
-			ROWbit : OUT STD_LOGIC_VECTOR(7 DOWNTO 0);
+			row_mask : IN STD_LOGIC_VECTOR(7 DOWNTO 0);
+			kbd_int : OUT STD_LOGIC;
 			swnmi : OUT STD_LOGIC;
 			swrst : OUT STD_LOGIC
 		);
@@ -373,9 +375,9 @@ BEGIN
       mix         => PSG_OUT,
 
       ioad        => "ZZZZZZZZ",
-      ioaq        => ym_o_ioa,
+      ioaq        => psg_ioa_out,
       iobd        => "ZZZZZZZZ",
-      iobq        => open,
+      iobq        => psg_iob_out,
 
       sel         => '1'
     );
@@ -389,9 +391,9 @@ BEGIN
 		key_extended => key_extended,
 		key_strobe => key_strobe,
 		key_code => key_code,
-		row => ym_o_ioa,
 		col => via_pb_out (2 DOWNTO 0),
-		ROWbit => KEY_ROW,
+		kbd_int => kbd_int,
+		row_mask => psg_ioa_out,
 		swnmi => swnmi,
 		swrst => swrst
 	);
@@ -454,8 +456,7 @@ BEGIN
 
 	via_pa_in <= (via_pa_out AND NOT via_pa_out_oe) OR (via_pa_in_from_psg AND via_pa_out_oe);
 	via_pb_in(2 DOWNTO 0) <= via_pb_out(2 DOWNTO 0);
-	via_pb_in(3) <= '0' WHEN ((KEY_ROW AND (ym_o_ioa XOR x"FF"))) = x"00" ELSE
-	'1';
+	via_pb_in(3) <= kbd_int;
 	via_pb_in(4) <= via_pb_out(4);
 	via_pb_in(5) <= 'Z';
 	via_pb_in(6) <= via_pb_out(6);

--- a/rtl/psg.v
+++ b/rtl/psg.v
@@ -118,24 +118,28 @@ always @(posedge clock, negedge reset)
 		endcase
 
 always @(*)
-	case(addr)
-		 0: q = a_period[ 7:0];
-		 1: q = { 4'd0, a_period[11:8] };
-		 2: q = b_period[ 7:0];
-		 3: q = { 4'd0, b_period[11:8] };
-		 4: q = c_period[ 7:0];
-		 5: q = { 4'd0, c_period[11:8] };
-		 6: q = { 3'd0, n_period };
-		 7: q = { b_data_io, a_data_io, c_mix_noise, b_mix_noise, a_mix_noise, c_enable, b_enable, a_enable };
-		 8: q = { 3'd0, a_mode, a_level };
-		 9: q = { 3'd0, b_mode, b_level };
-		10: q = { 3'd0, c_mode, c_level };
-		11: q = e_period[ 7:0];
-		12: q = e_period[15:8];
-		13: q = 8'b0; //{4'd0, e_continue, e_attack, e_alternate, e_hold };
-		14: q = a_data_io ? a_data : ioad;
-		15: q = b_data_io ? b_data : iobd;
-	endcase
+	if (!bdir && !bc1) begin
+		q = 8'bzzzzzzzz;
+	end else begin
+		case(addr)
+			 0: q = a_period[ 7:0];
+			 1: q = { 4'd0, a_period[11:8] };
+			 2: q = b_period[ 7:0];
+			 3: q = { 4'd0, b_period[11:8] };
+			 4: q = c_period[ 7:0];
+			 5: q = { 4'd0, c_period[11:8] };
+			 6: q = { 3'd0, n_period };
+			 7: q = { b_data_io, a_data_io, c_mix_noise, b_mix_noise, a_mix_noise, c_enable, b_enable, a_enable };
+			 8: q = { 3'd0, a_mode, a_level };
+			 9: q = { 3'd0, b_mode, b_level };
+			10: q = { 3'd0, c_mode, c_level };
+			11: q = e_period[ 7:0];
+			12: q = e_period[15:8];
+			13: q = 8'b0; //{4'd0, e_continue, e_attack, e_alternate, e_hold };
+			14: q = a_data_io ? a_data : ioad;
+			15: q = b_data_io ? b_data : iobd;
+		endcase
+	end
 
 //-------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds support for the two most common joystick interfaces for the Oric 1 and Atmos.
A setting has been added in order for the user to choose between PASE and IJK interfaces.
I also had to rework the keyboard code to make it closer to what's happening in a real computer.